### PR TITLE
Add Polygon wBTC payout plan reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # SOLA
+
+Referenz-Spezifikation und Beispiel-Smart-Contracts für wBTC/USDT-Auszahlungspläne auf Polygon.
+
+- `contracts/ParticipantPlan.sol`: Per-Teilnehmer-Vertrag, der Einzahlungen hält, monatliche Payouts steuert und Drains/Notfälle in den Pool sendet.
+- `contracts/CommunityPool.sol`: Gemeinsamer Pool, der wBTC aus Drains/Notfällen sammelt und an nicht-auszahlende Pläne + Provider verteilt.
+- `docs/payout-plan.md`: Prozess- und Regelbeschreibung der Aufteilung in Plan- und Pool-Vertrag.
+- `frontend/index.html`: Leichtgewichtige, rein lokale Demo-Oberfläche zur Simulation von Plan/Payout/Pool-Flows.

--- a/contracts/CommunityPool.sol
+++ b/contracts/CommunityPool.sol
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/**
+ * @title CommunityPool
+ * @notice Holds pooled wBTC from participant plans (inactive drains or emergency exits) and distributes it
+ *         monthly to eligible participants plus a provider fee and fee buffer.
+ *
+ * Distribution split:
+ * - 1% provider
+ * - 98% to plans that have NOT reached their payout phase (weighted by initial deposit)
+ * - 1% retained in the pool for transaction fees
+ *
+ * Eligibility and weights are managed by the individual plan contracts through callbacks.
+ */
+contract CommunityPool {
+    // --- Interfaces ---
+    interface IERC20 {
+        function balanceOf(address account) external view returns (uint256);
+        function transfer(address recipient, uint256 amount) external returns (bool);
+    }
+
+    // --- Storage ---
+    IERC20 public immutable wbtc;
+    address public immutable providerWallet;
+
+    uint256 private constant PERCENT_DIVISOR = 10_000; // 1% = 100
+
+    struct PlanInfo {
+        address creator;
+        uint256 weight; // Initial deposit (or other agreed weight)
+        bool eligible; // true if the plan has NOT entered payout phase
+        bool exists;
+    }
+
+    mapping(address => PlanInfo) public plans; // plan contract address => info
+    uint256 public communityBalance; // wBTC tracked for distribution (should be <= on-chain balance)
+
+    // --- Events ---
+    event PlanRegistered(address indexed plan, address indexed creator, uint256 weight, bool eligible);
+    event PlanEligibilityUpdated(address indexed plan, bool eligible);
+    event PlanRemoved(address indexed plan);
+    event PoolIncreased(address indexed plan, uint256 amount, uint256 newBalance);
+    event PoolDistributed(uint256 total, uint256 toProvider, uint256 toParticipants, uint256 retainedForFees);
+
+    constructor(address _wbtc, address _providerWallet) {
+        require(_wbtc != address(0) && _providerWallet != address(0), "zero address");
+        wbtc = IERC20(_wbtc);
+        providerWallet = _providerWallet;
+    }
+
+    // --- Plan management (only callable by plan contracts) ---
+
+    function registerPlan(address creator, uint256 weight, bool eligible) external {
+        require(!plans[msg.sender].exists, "already registered");
+        require(creator != address(0), "creator required");
+        plans[msg.sender] = PlanInfo({creator: creator, weight: weight, eligible: eligible, exists: true});
+        emit PlanRegistered(msg.sender, creator, weight, eligible);
+    }
+
+    function setEligibility(bool eligible) external {
+        PlanInfo storage info = _requirePlan(msg.sender);
+        info.eligible = eligible;
+        emit PlanEligibilityUpdated(msg.sender, eligible);
+    }
+
+    function removePlan() external {
+        PlanInfo storage info = _requirePlan(msg.sender);
+        delete plans[msg.sender];
+        emit PlanRemoved(msg.sender);
+    }
+
+    /**
+     * @notice Plans call this after transferring wBTC to the pool.
+     */
+    function notifyInbound(uint256 amount) external {
+        _requirePlan(msg.sender);
+        require(amount > 0, "amount required");
+        communityBalance += amount;
+        require(wbtc.balanceOf(address(this)) >= communityBalance, "insufficient wbtc");
+        emit PoolIncreased(msg.sender, amount, communityBalance);
+    }
+
+    // --- Distribution ---
+
+    function distribute(address[] calldata candidatePlans) external {
+        uint256 pool = communityBalance;
+        require(pool > 0, "nothing to distribute");
+        require(wbtc.balanceOf(address(this)) >= pool, "insufficient wbtc");
+
+        uint256 totalWeight;
+        uint256[] memory weights = new uint256[](candidatePlans.length);
+        address[] memory creators = new address[](candidatePlans.length);
+
+        for (uint256 i = 0; i < candidatePlans.length; i++) {
+            PlanInfo memory info = plans[candidatePlans[i]];
+            if (!info.exists || !info.eligible || info.weight == 0) continue;
+            weights[i] = info.weight;
+            creators[i] = info.creator;
+            totalWeight += info.weight;
+        }
+        require(totalWeight > 0, "no eligible plans");
+
+        uint256 toProvider = (pool * 100) / PERCENT_DIVISOR; // 1%
+        uint256 toParticipants = (pool * 9800) / PERCENT_DIVISOR; // 98%
+        uint256 retainedForFees = pool - toProvider - toParticipants; // 1%
+
+        communityBalance = retainedForFees;
+
+        require(wbtc.transfer(providerWallet, toProvider), "provider transfer failed");
+
+        for (uint256 i = 0; i < candidatePlans.length; i++) {
+            if (weights[i] == 0) continue;
+            uint256 share = (toParticipants * weights[i]) / totalWeight;
+            if (share > 0) {
+                require(wbtc.transfer(creators[i], share), "participant transfer failed");
+            }
+        }
+
+        emit PoolDistributed(pool, toProvider, toParticipants, retainedForFees);
+    }
+
+    // --- Internal ---
+
+    function _requirePlan(address plan) internal view returns (PlanInfo storage info) {
+        info = plans[plan];
+        require(info.exists, "unknown plan");
+    }
+}

--- a/contracts/ParticipantPlan.sol
+++ b/contracts/ParticipantPlan.sol
@@ -1,0 +1,256 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "./CommunityPool.sol";
+
+/**
+ * @title ParticipantPlan
+ * @notice Individual payout plan contract controlled by a single creator wallet.
+ *         - Deposits are held in wBTC
+ *         - Thresholds and payout sizing are expressed in USDT but converted to wBTC via an oracle
+ *         - Emergency exits and inactivity drains send wBTC to the shared CommunityPool
+ */
+contract ParticipantPlan {
+    // --- Token + Oracle Interfaces ---
+
+    interface IERC20 {
+        function balanceOf(address account) external view returns (uint256);
+        function transfer(address recipient, uint256 amount) external returns (bool);
+        function allowance(address owner, address spender) external view returns (uint256);
+        function approve(address spender, uint256 amount) external returns (bool);
+        function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+        function decimals() external view returns (uint8);
+    }
+
+    interface AggregatorV3Interface {
+        function decimals() external view returns (uint8);
+        function latestRoundData()
+            external
+            view
+            returns (
+                uint80 roundId,
+                int256 answer,
+                uint256 startedAt,
+                uint256 updatedAt,
+                uint80 answeredInRound
+            );
+    }
+
+    // --- Storage ---
+
+    IERC20 public immutable wbtc;
+    AggregatorV3Interface public immutable wbtcUsdOracle; // Expected to return wBTC price in USD with 8 decimals.
+    CommunityPool public immutable communityPool;
+
+    address public immutable creator; // Wallet that provided the initial deposit and is the exclusive payout recipient.
+    uint256 public immutable thresholdUSDT; // 6-decimal USDT amount that triggers payout phase.
+    uint256 public immutable monthlyPayoutUSDT; // 6-decimal USDT amount converted to wBTC at payout time.
+    uint256 public immutable initialDeposit; // In wBTC wei.
+
+    uint256 public totalDeposits; // All deposits (creator + others) in wBTC wei.
+    uint256 public escrowBalance; // WBTC currently owned by the plan.
+    uint256 public lastPayoutAt; // Timestamp of the last monthly payout trigger.
+    uint256 public lastDepositAt; // Timestamp of the last deposit (creator or external).
+    uint256 public inactiveDrainStart; // Timestamp when inactivity draining began (0 if not started).
+    bool public inPayoutPhase; // True once threshold reached.
+    bool public closed; // Plan is concluded (drained/emergency).
+
+    uint256 private constant MONTH = 30 days;
+    uint256 private constant PERCENT_DIVISOR = 10_000; // Basis points (1% = 100).
+
+    // --- Events ---
+
+    event DepositAdded(address indexed sender, uint256 amount);
+    event PayoutTriggered(uint256 wbtcAmount, uint256 price, uint256 timestamp);
+    event EmergencyExit(uint256 toCreator, uint256 toPool);
+    event InactivityDrain(uint256 wbtcAmount, uint256 remaining);
+
+    constructor(
+        address _wbtc,
+        address _wbtcUsdOracle,
+        address _communityPool,
+        uint256 _thresholdUSDT,
+        uint256 _monthlyPayoutUSDT,
+        uint256 _initialDeposit
+    ) {
+        require(_wbtc != address(0) && _wbtcUsdOracle != address(0) && _communityPool != address(0), "zero address");
+        require(_thresholdUSDT > 0 && _monthlyPayoutUSDT > 0, "invalid config");
+        require(_initialDeposit > 0, "initial deposit required");
+
+        wbtc = IERC20(_wbtc);
+        wbtcUsdOracle = AggregatorV3Interface(_wbtcUsdOracle);
+        communityPool = CommunityPool(_communityPool);
+
+        creator = msg.sender;
+        thresholdUSDT = _thresholdUSDT;
+        monthlyPayoutUSDT = _monthlyPayoutUSDT;
+        initialDeposit = _initialDeposit;
+
+        // Pull wBTC from creator
+        _pullToken(wbtc, msg.sender, address(this), _initialDeposit);
+        totalDeposits = _initialDeposit;
+        escrowBalance = _initialDeposit;
+        lastPayoutAt = block.timestamp;
+        lastDepositAt = block.timestamp;
+
+        if (_usdtValueOfWbtc(totalDeposits) >= thresholdUSDT) {
+            inPayoutPhase = true;
+        }
+
+        // Register with community pool (eligible only if not yet in payout phase)
+        communityPool.registerPlan(creator, initialDeposit, !inPayoutPhase);
+
+        emit DepositAdded(msg.sender, _initialDeposit);
+    }
+
+    // --- Plan lifecycle ---
+
+    /**
+     * @notice Allows anyone to add wBTC to this plan.
+     */
+    function contribute(uint256 amount) external {
+        require(!closed, "plan closed");
+        require(amount > 0, "amount required");
+
+        _pullToken(wbtc, msg.sender, address(this), amount);
+        totalDeposits += amount;
+        escrowBalance += amount;
+        lastDepositAt = block.timestamp;
+
+        if (!inPayoutPhase && _usdtValueOfWbtc(totalDeposits) >= thresholdUSDT) {
+            inPayoutPhase = true;
+            communityPool.setEligibility(false);
+        }
+
+        emit DepositAdded(msg.sender, amount);
+    }
+
+    // --- Payout logic ---
+
+    /**
+     * @notice Creator triggers a monthly payout once in the payout phase.
+     */
+    function triggerMonthlyPayout() external {
+        require(msg.sender == creator, "only creator");
+        require(!closed, "plan closed");
+        require(inPayoutPhase, "threshold not met");
+        require(block.timestamp >= lastPayoutAt + MONTH, "too soon");
+
+        uint256 wbtcAmount = _convertUSDTToWbtc(monthlyPayoutUSDT);
+        if (wbtcAmount > escrowBalance) {
+            wbtcAmount = escrowBalance;
+        }
+        require(wbtcAmount > 0, "nothing to withdraw");
+
+        lastPayoutAt = block.timestamp;
+        inactiveDrainStart = 0; // reset inactivity schedule
+
+        _pushToken(wbtc, creator, wbtcAmount);
+        escrowBalance -= wbtcAmount;
+        emit PayoutTriggered(wbtcAmount, _latestWbtcUsd(), block.timestamp);
+
+        if (escrowBalance == 0) {
+            closed = true;
+            communityPool.removePlan();
+        }
+    }
+
+    /**
+     * @notice Emergency exit: 90% to creator, 10% to community pool.
+     */
+    function emergencyExit() external {
+        require(msg.sender == creator, "only creator");
+        require(!closed, "plan closed");
+
+        uint256 balance = escrowBalance;
+        require(balance > 0, "no funds");
+
+        uint256 toCreator = (balance * 9000) / PERCENT_DIVISOR; // 90%
+        uint256 toPool = balance - toCreator; // 10%
+
+        closed = true;
+        escrowBalance = 0;
+
+        _pushToken(wbtc, creator, toCreator);
+        _pushToken(wbtc, address(communityPool), toPool);
+        communityPool.notifyInbound(toPool);
+        communityPool.removePlan();
+
+        emit EmergencyExit(toCreator, toPool);
+    }
+
+    /**
+     * @notice Anyone can start or continue inactivity draining after 90 days without participant activity.
+     *         10% of the current balance is moved to the community pool per month until the plan is empty or the creator resumes payouts.
+     */
+    function drainInactive() external {
+        require(!closed, "plan closed");
+        require(block.timestamp >= lastPayoutAt + 90 days, "not inactive");
+
+        if (inactiveDrainStart == 0) {
+            inactiveDrainStart = block.timestamp;
+        } else {
+            require(block.timestamp >= inactiveDrainStart + MONTH, "drain too soon");
+            inactiveDrainStart = block.timestamp;
+        }
+
+        uint256 balance = escrowBalance;
+        require(balance > 0, "empty");
+
+        uint256 toPool = (balance * 1000) / PERCENT_DIVISOR; // 10%
+        if (toPool == 0) {
+            toPool = balance;
+        }
+
+        escrowBalance -= toPool;
+        _pushToken(wbtc, address(communityPool), toPool);
+        communityPool.notifyInbound(toPool);
+        emit InactivityDrain(toPool, escrowBalance);
+
+        if (escrowBalance == 0) {
+            closed = true;
+            communityPool.removePlan();
+        }
+    }
+
+    // --- View helpers ---
+
+    function planBalance() external view returns (uint256) {
+        return escrowBalance;
+    }
+
+    // --- Internal helpers ---
+
+    function _convertUSDTToWbtc(uint256 amountUSDT) internal view returns (uint256) {
+        uint256 price = _latestWbtcUsd(); // 8 decimals typically
+        uint8 priceDecimals = wbtcUsdOracle.decimals();
+        uint8 wbtcDecimals = wbtc.decimals();
+        require(price > 0, "oracle error");
+        require(priceDecimals >= 6, "oracle decimals");
+
+        uint256 numerator = amountUSDT * (10 ** wbtcDecimals) * (10 ** priceDecimals);
+        return numerator / price / (10 ** 6);
+    }
+
+    function _usdtValueOfWbtc(uint256 amountWbtc) internal view returns (uint256) {
+        uint256 price = _latestWbtcUsd();
+        uint8 priceDecimals = wbtcUsdOracle.decimals();
+        uint8 wbtcDecimals = wbtc.decimals();
+        require(priceDecimals >= 6, "oracle decimals");
+        return (amountWbtc * price) / (10 ** wbtcDecimals) / (10 ** (priceDecimals - 6));
+    }
+
+    function _latestWbtcUsd() internal view returns (uint256) {
+        (, int256 answer,, uint256 updatedAt,) = wbtcUsdOracle.latestRoundData();
+        require(answer > 0 && updatedAt + 1 days > block.timestamp, "stale oracle");
+        return uint256(answer);
+    }
+
+    function _pullToken(IERC20 token, address from, address to, uint256 amount) internal {
+        require(token.transferFrom(from, to, amount), "transferFrom failed");
+    }
+
+    function _pushToken(IERC20 token, address to, uint256 amount) internal {
+        require(token.transfer(to, amount), "transfer failed");
+    }
+}

--- a/docs/payout-plan.md
+++ b/docs/payout-plan.md
@@ -1,0 +1,73 @@
+# Polygon wBTC/USDT Auszahlungskonzept
+
+Dieses Dokument beschreibt das Referenz-Design der beiden Smart-Contract-Rollen:
+
+- **Gemeinschaftspool**: Pool, der durch Notfall- oder Inaktivitäts-Drains befüllt wird und jeden Monat ausgeschüttet wird.
+- **Teilnehmer-Plan**: Individueller Auszahlungsplan pro Teilnehmer, der seine Parameter vorgibt und nur an die Ersteller-Wallet auszahlt.
+
+## Token- & Orakel-Annahmen
+- Einzahlungen und Auszahlungen erfolgen in **wBTC**.
+- Schwellenwert und monatliche Auszahlung werden in **USDT** angegeben und beim Auslösen in wBTC umgerechnet.
+- Ein Chainlink-Feed liefert den wBTC/USD-Preis (Standard: 8 Dezimalstellen). Eine einfache USDT = USD Annahme wird verwendet.
+
+## Architektur: zwei getrennte Verträge
+- **ParticipantPlan (pro Teilnehmer)**: Custodied das plan-spezifische wBTC-Guthaben, führt Payouts an den Ersteller aus und sendet Anteile an den Pool bei Notfall oder Inaktivität.
+- **CommunityPool (gemeinsam)**: Nimmt wBTC aus Notfall-/Inaktivitäts-Drains entgegen und schüttet monatlich aus (1 % Provider, 98 % an nicht-auszahlende Teilnehmer nach Gewicht, 1 % Fee-Buffer).
+
+## Kernregeln pro Plan (ParticipantPlan)
+1. **Plan-Erstellung**
+   - Constructor zieht `initialDeposit` in wBTC vom Ersteller und speichert:
+     - `thresholdUSDT`: USDT-Schwelle, ab der die Auszahlungsphase startet.
+     - `monthlyPayoutUSDT`: USDT-Wert einer Monatszahlung, bei Auslösung in wBTC umgerechnet.
+   - Weitere wBTC-Einzahlungen sind von beliebigen Wallets möglich.
+   - Erreicht die Summe der Einzahlungen den Schwellenwert (Oracle-basiert), wechselt der Plan in die Auszahlungsphase und meldet sich im Pool als nicht-eligible ab.
+
+2. **Monatliche Auszahlungen**
+   - Nur die Ersteller-Wallet darf monatliche Auszahlungen triggern (Pull-Modell).
+   - Monat = 30 Tage (blocktimestamp-basiert).
+   - Payout-Betrag wird beim Auslösen von USDT in wBTC umgerechnet. Ist das Guthaben geringer, wird der Rest ausgezahlt und der Plan geschlossen (und im Pool deregistriert).
+
+3. **Notfallauszahlung**
+   - Jederzeit vom Ersteller aufrufbar.
+   - 90 % des Plan-Guthabens gehen an den Ersteller, 10 % werden an den CommunityPool gesendet. Der Plan wird geschlossen und im Pool entfernt.
+
+4. **Inaktivität**
+   - Nach 90 Tagen ohne Payout kann jeder monatlich einen Drain anstoßen:
+     - 10 % des aktuellen Guthabens wandern pro Monat in den CommunityPool, bis Guthaben = 0 oder der Ersteller wieder auszahlt.
+   - Sobald Guthaben 0, Plan geschlossen und im Pool deregistriert.
+
+## Gemeinschaftspool-Regeln (CommunityPool)
+1. **Registrierung & Eligibility**
+   - Plans registrieren sich beim Pool mit ihrer Ersteller-Adresse und Gewicht (= Initialeinzahlung).
+   - Wird ein Plan auszahlungsreif, meldet er sich als nicht-eligible; bei Schließung entfernt er sich vollständig.
+2. **Ausschüttung**
+   - Funktion `distribute(candidatePlans[])` verteilt das angesammelte Pool-Guthaben:
+     - 1 % an Provider-Wallet.
+     - 98 % an Pläne, die noch nicht in der Auszahlungsphase sind (Gewichtung nach Initialeinzahlung).
+     - 1 % verbleibt als Fee-Buffer im Pool.
+   - Die Kandidatenliste begrenzt die Gas-Kosten und wird off-chain zusammengestellt.
+
+## Datenmodell (Solidity)
+- `ParticipantPlan`
+  - `creator`, `initialDeposit`, `totalDeposits`, `escrowBalance`
+  - `thresholdUSDT`, `monthlyPayoutUSDT`
+  - `lastPayoutAt`, `lastDepositAt`, `inactiveDrainStart`
+  - `inPayoutPhase`, `closed`
+- `CommunityPool`
+  - `plans[plan] = {creator, weight, eligible}`
+  - `communityBalance`: WBTC-Betrag, der auszuschütten ist (Rest 1 % verbleibt)
+
+## Sicherheit & Grenzen
+- Pull-basiertes Auslösen reduziert Automatisierungsrisiken.
+- Monatliche Dauer = 30 Tage; reale Kalendermonate erfordern ggf. Off-Chain-Scheduler.
+- Orakel-Staleness-Check (max. 1 Tag alt) verhindert alte Preise.
+- Kein Reentrancy-Guard in der Referenz (für Produktion empfohlen).
+- Die Kandidatenliste für Pool-Ausschüttungen muss off-chain kuratiert werden, um Gas zu begrenzen.
+
+## Erweiterungsmöglichkeiten
+- **Plan-Factory + Upgradebarkeit**: Eine Factory erzeugt dedizierte Plan-Instanzen; ein UUPS/Transparent-Proxy sichert zukünftige Upgrades (z. B. neue Tokens, andere Gebührenlogik).
+- **Preis-Fallbacks**: Neben Chainlink-Feed optionaler DEX-TWAP (z. B. Uniswap V3) als Backstop; Guardrails wie Mindest-Liquidität und Max-Drift gegenüber Hauptorakel.
+- **Multi-Stablecoin**: Unterstützung weiterer Stablecoins (USDC/DAI) mit einheitlichem 6-Decimals-Interface und token-spezifischen Preisfeeds.
+- **Automatisierung**: Chainlink Automation/gelernte Keeper-Services zum periodischen Auslösen von Monats-Payouts und Inaktivitäts-Drains, inkl. Pausier-Flag für Wartung.
+- **Sicherheitsmodule**: ReentrancyGuards, pausierbare Funktionen, Rate-Limits für Emergency/Drain-Aufrufe und Rolling-Orakel-Drift-Checks.
+- **Analytics & Off-Chain-Indexing**: The Graph/Substreams für Events (PayoutTriggered, EmergencyExit, CommunityDistributed) zur Abrechnung und UI-Visualisierung.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,392 @@
+<!DOCTYPE html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SOLA – wBTC/USDT Auszahlungsplan Demo</title>
+    <style>
+      :root {
+        color-scheme: light;
+        --bg: #0f172a;
+        --card: #111827;
+        --muted: #9ca3af;
+        --accent: #38bdf8;
+        --text: #e5e7eb;
+        --border: #1f2937;
+        --error: #f87171;
+        --success: #4ade80;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+        background: radial-gradient(circle at 20% 20%, #0b172a, #0a0f1f 40%, #070b16);
+        color: var(--text);
+        min-height: 100vh;
+        padding: 32px 16px 64px;
+        display: flex;
+        justify-content: center;
+      }
+      .layout {
+        width: min(1200px, 100%);
+        display: grid;
+        gap: 16px;
+        grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+      }
+      .card {
+        background: rgba(17, 24, 39, 0.9);
+        border: 1px solid var(--border);
+        border-radius: 16px;
+        padding: 16px;
+        box-shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
+      }
+      h1,
+      h2,
+      h3 {
+        margin: 0 0 12px;
+      }
+      p {
+        margin: 0 0 10px;
+        color: var(--muted);
+      }
+      label {
+        display: block;
+        font-size: 14px;
+        margin-bottom: 6px;
+        color: var(--muted);
+      }
+      input {
+        width: 100%;
+        padding: 10px 12px;
+        background: #0b1220;
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        color: var(--text);
+        outline: none;
+        transition: border 120ms ease;
+      }
+      input:focus {
+        border-color: var(--accent);
+      }
+      .row {
+        display: grid;
+        gap: 12px;
+        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+        margin-bottom: 12px;
+      }
+      button {
+        width: 100%;
+        padding: 10px 12px;
+        border: 1px solid var(--accent);
+        background: linear-gradient(135deg, #0ea5e9, #22d3ee);
+        color: #0b1220;
+        border-radius: 10px;
+        cursor: pointer;
+        font-weight: 700;
+        transition: filter 120ms ease, transform 120ms ease;
+      }
+      button.secondary {
+        background: transparent;
+        color: var(--accent);
+      }
+      button:hover {
+        filter: brightness(1.06);
+        transform: translateY(-1px);
+      }
+      .muted {
+        color: var(--muted);
+        font-size: 14px;
+      }
+      .pill {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        padding: 6px 10px;
+        border-radius: 999px;
+        background: rgba(56, 189, 248, 0.12);
+        color: var(--accent);
+        font-size: 13px;
+        border: 1px solid rgba(56, 189, 248, 0.3);
+        margin-right: 6px;
+      }
+      .log {
+        max-height: 320px;
+        overflow: auto;
+        background: #0b1220;
+        border-radius: 12px;
+        padding: 12px;
+        font-size: 14px;
+        border: 1px solid var(--border);
+      }
+      .log-entry + .log-entry {
+        margin-top: 6px;
+        padding-top: 6px;
+        border-top: 1px dashed var(--border);
+      }
+      .log-entry time {
+        color: var(--muted);
+        font-size: 12px;
+        display: block;
+      }
+      .badge-success {
+        color: var(--success);
+      }
+      .badge-error {
+        color: var(--error);
+      }
+      .state {
+        display: grid;
+        gap: 8px;
+      }
+      .state div {
+        display: flex;
+        justify-content: space-between;
+        border-bottom: 1px dashed var(--border);
+        padding-bottom: 4px;
+        font-size: 14px;
+      }
+    </style>
+  </head>
+  <body>
+    <main class="layout">
+      <section class="card" style="grid-column: span 2;">
+        <h1>SOLA: wBTC/USDT Auszahlungsplan (Demo-Frontend)</h1>
+        <p>
+          Diese rein lokale Demo spiegelt die Kernflüsse der Smart Contracts wider: Plan-Erstellung, Einzahlungen,
+          monatliche Auszahlungen, Notfallauszahlung, Inaktivitäts-Drain und Ausschüttung aus dem Community-Pool.
+          Werte werden nicht on-chain geschrieben, sondern lokal simuliert.
+        </p>
+        <div class="pill">CommunityPool</div>
+        <div class="pill">ParticipantPlan</div>
+      </section>
+
+      <section class="card">
+        <h2>Plan anlegen</h2>
+        <div class="row">
+          <div>
+            <label>Initial wBTC</label>
+            <input id="initialWbtc" type="number" min="0" step="0.0001" value="0.25" />
+          </div>
+          <div>
+            <label>Schwelle USDT</label>
+            <input id="thresholdUsdt" type="number" min="1" step="1" value="10000" />
+          </div>
+        </div>
+        <div class="row">
+          <div>
+            <label>Monatliche Auszahlung USDT</label>
+            <input id="monthlyUsdt" type="number" min="1" step="1" value="500" />
+          </div>
+          <div>
+            <label>wBTC/USD Preis (Oracle)</label>
+            <input id="price" type="number" min="1" step="1000" value="65000" />
+          </div>
+        </div>
+        <button id="createPlan">Plan erstellen</button>
+        <p class="muted">Hinweis: Die Eligibility im Pool wechselt auf „true“ sobald die Schwelle noch nicht erreicht ist; beim Erreichen wird sie deaktiviert.</p>
+      </section>
+
+      <section class="card">
+        <h2>Aktionen</h2>
+        <div class="row">
+          <div>
+            <label>Zusätzliche Einzahlung (wBTC)</label>
+            <input id="contribWbtc" type="number" min="0" step="0.01" value="0.05" />
+            <button id="contribute">Einzahlen</button>
+          </div>
+          <div>
+            <label>Zeit seit letztem Payout (Tage)</label>
+            <input id="daysElapsed" type="number" min="0" step="1" value="30" />
+            <button id="payout">Monatliche Auszahlung</button>
+          </div>
+        </div>
+        <div class="row">
+          <button id="emergency" class="secondary">Notfallauszahlung (90/10)</button>
+          <button id="drain">Inaktivitäts-Drain (10%)</button>
+          <button id="distribute">Pool ausschütten</button>
+        </div>
+      </section>
+
+      <section class="card">
+        <h2>Status</h2>
+        <div class="state" id="state"></div>
+      </section>
+
+      <section class="card" style="grid-column: span 2;">
+        <h2>Events</h2>
+        <div class="log" id="log"></div>
+      </section>
+    </main>
+
+    <script>
+      const state = {
+        planCreated: false,
+        thresholdUSDT: 0,
+        monthlyUSDT: 0,
+        price: 0,
+        wbtcBalance: 0,
+        pool: 0,
+        eligibility: false, // eligible for pool distribution (true if not in payout phase)
+        inPayoutPhase: false,
+        lastPayoutDays: 0,
+      };
+
+      const stateEl = document.getElementById("state");
+      const logEl = document.getElementById("log");
+
+      function usdToWbtc(usdt, price) {
+        return usdt / price;
+      }
+
+      function appendLog(message, badge) {
+        const entry = document.createElement("div");
+        entry.className = "log-entry";
+        const time = new Date().toLocaleTimeString();
+        entry.innerHTML = `<time>${time}</time><div>${badge ? `<span class="pill">${badge}</span>` : ""}${message}</div>`;
+        logEl.prepend(entry);
+      }
+
+      function render() {
+        stateEl.innerHTML = `
+          <div><span>Plan erstellt</span><strong>${state.planCreated ? "Ja" : "Nein"}</strong></div>
+          <div><span>In Payout-Phase</span><strong>${state.inPayoutPhase ? "Ja" : "Nein"}</strong></div>
+          <div><span>Eligibility im Pool</span><strong>${state.eligibility ? "Ja" : "Nein"}</strong></div>
+          <div><span>Plan-Guthaben (wBTC)</span><strong>${state.wbtcBalance.toFixed(6)}</strong></div>
+          <div><span>Community Pool (wBTC)</span><strong>${state.pool.toFixed(6)}</strong></div>
+          <div><span>Schwelle (USDT)</span><strong>${state.thresholdUSDT}</strong></div>
+          <div><span>Monats-Payout (USDT)</span><strong>${state.monthlyUSDT}</strong></div>
+          <div><span>wBTC/USD Preis</span><strong>${state.price}</strong></div>
+          <div><span>Tage seit letztem Payout</span><strong>${state.lastPayoutDays}</strong></div>
+        `;
+      }
+
+      function requirePlan() {
+        if (!state.planCreated) throw new Error("Plan ist noch nicht erstellt.");
+      }
+
+      document.getElementById("createPlan").onclick = () => {
+        const initial = Number(document.getElementById("initialWbtc").value);
+        const threshold = Number(document.getElementById("thresholdUsdt").value);
+        const monthly = Number(document.getElementById("monthlyUsdt").value);
+        const price = Number(document.getElementById("price").value);
+        if (initial <= 0 || threshold <= 0 || monthly <= 0 || price <= 0) {
+          appendLog("Ungültige Eingabe.", "Fehler");
+          return;
+        }
+        state.planCreated = true;
+        state.thresholdUSDT = threshold;
+        state.monthlyUSDT = monthly;
+        state.price = price;
+        state.wbtcBalance = initial;
+        state.pool = 0;
+        state.inPayoutPhase = usdToWbtc(threshold, price) <= initial;
+        state.eligibility = !state.inPayoutPhase;
+        state.lastPayoutDays = 0;
+        appendLog(
+          `Plan erstellt: initial ${initial} wBTC, Schwelle ${threshold} USDT, Monats-Payout ${monthly} USDT.`,
+          "Init"
+        );
+        render();
+      };
+
+      document.getElementById("contribute").onclick = () => {
+        try {
+          requirePlan();
+          const add = Number(document.getElementById("contribWbtc").value);
+          if (add <= 0) throw new Error("Betrag muss > 0 sein.");
+          state.wbtcBalance += add;
+          const thresholdWbtc = usdToWbtc(state.thresholdUSDT, state.price);
+          if (!state.inPayoutPhase && state.wbtcBalance >= thresholdWbtc) {
+            state.inPayoutPhase = true;
+            state.eligibility = false;
+          }
+          appendLog(`Einzahlung: +${add} wBTC. Neues Guthaben ${state.wbtcBalance.toFixed(6)} wBTC.`, "Deposit");
+          render();
+        } catch (e) {
+          appendLog(e.message, "Fehler");
+        }
+      };
+
+      document.getElementById("payout").onclick = () => {
+        try {
+          requirePlan();
+          const days = Number(document.getElementById("daysElapsed").value);
+          state.lastPayoutDays = days;
+          if (!state.inPayoutPhase) throw new Error("Schwelle nicht erreicht.");
+          if (days < 30) throw new Error("Mindestens 30 Tage seit letztem Payout erforderlich.");
+          let amount = usdToWbtc(state.monthlyUSDT, state.price);
+          if (amount > state.wbtcBalance) amount = state.wbtcBalance;
+          if (amount <= 0) throw new Error("Kein Guthaben vorhanden.");
+          state.wbtcBalance -= amount;
+          state.lastPayoutDays = 0;
+          appendLog(`Monatliche Auszahlung: ${amount.toFixed(6)} wBTC an Ersteller.`, "Payout");
+          if (state.wbtcBalance === 0) {
+            state.eligibility = false;
+            appendLog("Plan ist leer und gilt als geschlossen.", "Hinweis");
+          }
+          render();
+        } catch (e) {
+          appendLog(e.message, "Fehler");
+        }
+      };
+
+      document.getElementById("emergency").onclick = () => {
+        try {
+          requirePlan();
+          const bal = state.wbtcBalance;
+          if (bal <= 0) throw new Error("Kein Guthaben.");
+          const toCreator = bal * 0.9;
+          const toPool = bal - toCreator;
+          state.wbtcBalance = 0;
+          state.pool += toPool;
+          state.eligibility = false;
+          appendLog(
+            `Notfallauszahlung: ${toCreator.toFixed(6)} wBTC an Ersteller, ${toPool.toFixed(6)} wBTC in den Pool.`,
+            "Emergency"
+          );
+          render();
+        } catch (e) {
+          appendLog(e.message, "Fehler");
+        }
+      };
+
+      document.getElementById("drain").onclick = () => {
+        try {
+          requirePlan();
+          if (state.lastPayoutDays < 90) throw new Error("Inaktivität < 90 Tage.");
+          if (state.wbtcBalance <= 0) throw new Error("Kein Guthaben.");
+          const toPool = Math.max(state.wbtcBalance * 0.1, state.wbtcBalance < 0.000001 ? state.wbtcBalance : 0);
+          const drained = toPool > 0 ? toPool : state.wbtcBalance;
+          state.wbtcBalance -= drained;
+          state.pool += drained;
+          appendLog(`Inaktivitäts-Drain: ${drained.toFixed(6)} wBTC in den Pool.`, "Drain");
+          render();
+        } catch (e) {
+          appendLog(e.message, "Fehler");
+        }
+      };
+
+      document.getElementById("distribute").onclick = () => {
+        if (state.pool <= 0) {
+          appendLog("Pool ist leer.", "Fehler");
+          return;
+        }
+        const toProvider = state.pool * 0.01;
+        const toParticipants = state.pool * 0.98;
+        const retained = state.pool - toProvider - toParticipants;
+        appendLog(
+          `Pool-Ausschüttung: ${toProvider.toFixed(6)} wBTC Provider, ${toParticipants.toFixed(
+            6
+          )} wBTC an eligible Pläne, ${retained.toFixed(6)} wBTC verbleiben.`,
+          "Pool"
+        );
+        state.pool = retained;
+        render();
+      };
+
+      render();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- split the design into two contracts: ParticipantPlan per user and CommunityPool for shared distributions
- keep payout logic USDT-denominated with wBTC custody, plus threshold, monthly payouts, emergency exits, and inactivity drains into the pool
- document the two-contract architecture and add a lightweight local frontend demo for simulating plan/payout/pool flows

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953ccc8ace08331935de26a05230869)